### PR TITLE
Fix dependencies and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-,
+# FortuneAI
+
+This repository contains a small demo consisting of a FastAPI backend and a simple Vue/Vite frontend. The backend extracts fortune telling rules from text using OpenAI, while the frontend visualises and manages these rules.
+
+## Requirements
+
+- Python 3.12+
+- Node.js 20+
+
+## Setup
+
+1. **Install Python dependencies**
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+
+2. **Install Node dependencies**
+   ```bash
+   npm install
+   ```
+   The project uses `express`, `cors` and `dotenv` in addition to `openai`.
+
+3. **Environment variables**
+   - `OPENAI_API_KEY` should be set in a `.env` file or your shell environment.
+   - Optionally set `PORT` to change the port for the Node server.
+
+## Running the project
+
+Start the FastAPI server:
+```bash
+python backend/main.py
+# or with uvicorn
+uvicorn backend.main:app --reload
+```
+
+In another terminal, start the Node proxy:
+```bash
+npm start
+```
+
+The Vue application can then be served with Vite:
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The API will be available on `http://localhost:8000` by default and the frontend on `http://localhost:5173` when using `npm run dev`.

--- a/backend/main.py
+++ b/backend/main.py
@@ -133,3 +133,8 @@ async def add_rule(rule: dict):
     except Exception as e:
         logging.error(f"Error adding rule: {e}")
         raise HTTPException(status_code=500, detail="Failed to add rule")
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 openai
 python-multipart
+python-dotenv

--- a/frontend/server/index.js
+++ b/frontend/server/index.js
@@ -8,6 +8,11 @@ dotenv.config();
 const app = express();
 const port = process.env.PORT || 5000;
 
+if (!process.env.OPENAI_API_KEY) {
+  console.error('OPENAI_API_KEY not set');
+  process.exit(1);
+}
+
 app.use(cors());
 app.use(express.json());
 

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "main": "index.js",
   "type": "module",
   "dependencies": {
-    "openai": "^5.10.2"
+    "openai": "^5.10.2",
+    "express": "^4.19.2",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5"
   },
   "scripts": {
+    "start": "node frontend/server/index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add python-dotenv to backend requirements and add uvicorn entry point
- exit with message when OPENAI_API_KEY is missing
- document setup and running instructions
- include express server dependencies and start script

## Testing
- `npm test`
- `npm start` *(fails: Cannot find package 'express')*
- `pip install -r backend/requirements.txt` *(fails: could not find python-dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_688a45d20f7c8330a7fbf7c9d28b1352