### PR TITLE
Add Windows batch file for quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ npm install
 npm run dev
 ```
 
+### 3. Windows 자동 실행
+루트 디렉터리의 `run_dev.bat` 파일을 실행하면 백엔드와 프론트엔드가 각기 다른 콘솔 창에서 동시에 시작됩니다. 최초 실행 시에는 `backend/requirements.txt` 설치와 `frontend` 디렉터리의 `npm install`을 먼저 수행하세요.
+
 접속: http://localhost:5173
 
 ## 🧠 AI 추출 모델 학습

--- a/run_dev.bat
+++ b/run_dev.bat
@@ -1,0 +1,9 @@
+@echo off
+REM Start backend and frontend servers in separate windows
+
+REM Ensure dependencies are installed first
+REM   pip install -r backend\requirements.txt
+REM   (cd frontend && npm install)
+
+start "backend" cmd /k "cd backend && uvicorn main:app --reload --port 8000"
+start "frontend" cmd /k "cd frontend && npm run dev"


### PR DESCRIPTION
## Summary
- add `run_dev.bat` to start backend and frontend together on Windows
- document batch file usage in README

## Testing
- `npm test` *(fails: no test specified)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688b10f7dd1c8330b1f582e29c3bb3d5