### PR TITLE
fix: correct backend URL in frontend env

### DIFF
--- a/frontend/.env
+++ b/frontend/.env
@@ -1,3 +1,3 @@
 OPENAI_API_KEY=your-real-api-key-here
 
-VITE_BACKEND_URL=http:
+VITE_BACKEND_URL=http://localhost:5000


### PR DESCRIPTION
## Summary
- fix frontend backend URL

## Testing
- `npm test` (fails: Error: no test specified)
- `python -m json.tool backend/rules.json`

------
https://chatgpt.com/codex/tasks/task_e_6890a259136c8330abb09b8effd76a2b